### PR TITLE
pool

### DIFF
--- a/go/isuports.go
+++ b/go/isuports.go
@@ -189,7 +189,9 @@ func Run() {
 		e.Logger.Fatalf("failed to connect db: %v", err)
 		return
 	}
-	adminDB.SetMaxOpenConns(10)
+	adminDB.SetMaxIdleConns(100)
+	adminDB.SetMaxOpenConns(100)
+	adminDB.SetConnMaxLifetime(120 * time.Second)
 	defer adminDB.Close()
 
 	port := getEnv("SERVER_APP_PORT", "3000")


### PR DESCRIPTION
#1 
```
mysql> show global variables like '%connection%';
+-----------------------------------+----------------------+
| Variable_name                     | Value                |
+-----------------------------------+----------------------+
| character_set_connection          | utf8mb4              |
| collation_connection              | utf8mb4_0900_ai_ci   |
| connection_memory_chunk_size      | 8912                 |
| connection_memory_limit           | 18446744073709551615 |
| global_connection_memory_limit    | 18446744073709551615 |
| global_connection_memory_tracking | OFF                  |
| max_connections                   | 151                  |
| max_user_connections              | 0                    |
| mysqlx_max_connections            | 100                  |
+-----------------------------------+----------------------+
9 rows in set (0.01 sec)
```